### PR TITLE
Give package proper name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 # Install GPGTools.
 class gpgtools {
   package { 'GPGTools':
-    name     => 'Install.pkg',
+    name     => 'GPGTools.pkg',
     provider => 'pkgdmg',
     source   => 'https://releases.gpgtools.org/GPG%20Suite%20-%202013.10.22.dmg',
   }


### PR DESCRIPTION
The package was being installed in `/var/db` as `.puppet_pkgdmg_installed_Install.pkg`. Really the repo and package name should be renamed gpgsuite, so this is an interim fix.
