### PR TITLE
Update GPGTools to latest version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,6 @@ class gpgtools {
   package { 'GPGTools':
     name     => 'GPGTools.pkg',
     provider => 'pkgdmg',
-    source   => 'https://releases.gpgtools.org/GPG%20Suite%20-%202013.10.22.dmg',
+    source   => 'https://releases.gpgtools.org/GPG_Suite-2015.02-b5-1161.dmg',
   }
 }

--- a/spec/classes/gpgtools_spec.rb
+++ b/spec/classes/gpgtools_spec.rb
@@ -3,6 +3,6 @@ describe 'gpgtools' do
   it do
     should contain_class('gpgtools')
     should contain_package('GPGTools').with_provider('pkgdmg')
-    should contain_package('GPGTools').with_source('https://releases.gpgtools.org/GPG%20Suite%20-%202013.10.22.dmg')
+    should contain_package('GPGTools').with_source('https://releases.gpgtools.org/GPG_Suite-2015.02-b5-1161.dmg')
   end
 end


### PR DESCRIPTION
GPG Suite 2013.10.22 is not available on releases.gpgtools.org anymore.